### PR TITLE
Add license block to all files

### DIFF
--- a/examples/single-account/cloudtrail.tf
+++ b/examples/single-account/cloudtrail.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 module "cloudtrail" {
   count                 = local.cloudtrail_deploy ? 1 : 0
   source                = "../../modules/infrastructure/cloudtrail"

--- a/examples/single-account/main.tf
+++ b/examples/single-account/main.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #-------------------------------------
 # general resources
 #-------------------------------------

--- a/examples/single-account/outputs.tf
+++ b/examples/single-account/outputs.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 output "cloudtrail_sns_subscribed_sqs_url" {
   value       = module.sqs_sns_subscription.cloudtrail_sns_subscribed_sqs_url
   description = "URL of the cloudtrail-sns subscribed sqs"

--- a/examples/single-account/sqs.tf
+++ b/examples/single-account/sqs.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 locals {
   cloudtrail_deploy  = var.cloudtrail_sns_arn == "create"
   cloudtrail_sns_arn = local.cloudtrail_deploy ? module.cloudtrail[0].sns_topic_arn : var.cloudtrail_sns_arn

--- a/examples/single-account/variables.tf
+++ b/examples/single-account/variables.tf
@@ -1,4 +1,19 @@
-
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 #---------------------------------
 # optionals - with defaults

--- a/examples/single-account/versions.tf
+++ b/examples/single-account/versions.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 terraform {
   required_version = ">= 0.15.0"
   required_providers {

--- a/modules/infrastructure/cloudtrail/kms.tf
+++ b/modules/infrastructure/cloudtrail/kms.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_kms_key" "cloudtrail_kms" {
   count                   = var.cloudtrail_kms_enable ? 1 : 0
   is_enabled              = true

--- a/modules/infrastructure/cloudtrail/main.tf
+++ b/modules/infrastructure/cloudtrail/main.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail
 resource "aws_cloudtrail" "cloudtrail" {
 

--- a/modules/infrastructure/cloudtrail/outputs.tf
+++ b/modules/infrastructure/cloudtrail/outputs.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 output "sns_topic_arn" {
   value       = aws_sns_topic.cloudtrail.arn
   description = "ARN of Cloudtrail SNS topic"

--- a/modules/infrastructure/cloudtrail/s3.tf
+++ b/modules/infrastructure/cloudtrail/s3.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_s3_bucket" "cloudtrail" {
   bucket        = "${var.name}-${data.aws_caller_identity.me.account_id}"
   force_destroy = true

--- a/modules/infrastructure/cloudtrail/sns.tf
+++ b/modules/infrastructure/cloudtrail/sns.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_sns_topic" "cloudtrail" {
   name = var.name
   tags = var.tags

--- a/modules/infrastructure/cloudtrail/sns_permissions.tf
+++ b/modules/infrastructure/cloudtrail/sns_permissions.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_sns_topic_policy" "allow_cloudtrail_publish" {
   arn    = aws_sns_topic.cloudtrail.arn
   policy = data.aws_iam_policy_document.cloudtrail_sns.json

--- a/modules/infrastructure/cloudtrail/variables.tf
+++ b/modules/infrastructure/cloudtrail/variables.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #---------------------------------
 # optionals - with defaults
 #---------------------------------

--- a/modules/infrastructure/cloudtrail/versions.tf
+++ b/modules/infrastructure/cloudtrail/versions.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 terraform {
   required_version = ">= 0.15.0"
   required_providers {

--- a/modules/infrastructure/resource-group/main.tf
+++ b/modules/infrastructure/resource-group/main.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_resourcegroups_group" "falcosecurity_for_cloud" {
 
   name = var.name

--- a/modules/infrastructure/resource-group/outputs.tf
+++ b/modules/infrastructure/resource-group/outputs.tf
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/modules/infrastructure/resource-group/variables.tf
+++ b/modules/infrastructure/resource-group/variables.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 #---------------------------------
 # optionals - with default
 #---------------------------------

--- a/modules/infrastructure/resource-group/versions.tf
+++ b/modules/infrastructure/resource-group/versions.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 terraform {
   required_version = ">= 0.15.0"
   required_providers {

--- a/modules/infrastructure/sqs-sns-subscription/main.tf
+++ b/modules/infrastructure/sqs-sns-subscription/main.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 resource "aws_sqs_queue" "this" {
   name = var.name
   tags = var.tags

--- a/modules/infrastructure/sqs-sns-subscription/outputs.tf
+++ b/modules/infrastructure/sqs-sns-subscription/outputs.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 output "cloudtrail_sns_subscribed_sqs_url" {
   value       = aws_sqs_queue.this.url
   description = "URL of the cloudtrail-sns subscribed sqs"

--- a/modules/infrastructure/sqs-sns-subscription/variables.tf
+++ b/modules/infrastructure/sqs-sns-subscription/variables.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 variable "name" {
   type        = string
   description = "Queue name"

--- a/modules/infrastructure/sqs-sns-subscription/versions.tf
+++ b/modules/infrastructure/sqs-sns-subscription/versions.tf
@@ -1,3 +1,20 @@
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 terraform {
   required_version = ">= 0.15.0"
   required_providers {

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+# Copyright (C) 2022 The Falco Authors.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -euxo pipefail
 


### PR DESCRIPTION
The sysdiglabs version had a top-level license but not a per-file
license block. Add the per-file block to all files.

Signed-off-by: Mark Stemm <mark.stemm@gmail.com>